### PR TITLE
Add the side-bar and empty page for computational graph documentation

### DIFF
--- a/docs-site/docs/graph.md
+++ b/docs-site/docs/graph.md
@@ -1,0 +1,8 @@
+---
+id: graph
+title: Computational Graph
+---
+
+<!--- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.  -->
+
+SINGA supports buffering operation and computational graph.

--- a/docs-site/website/sidebars.json
+++ b/docs-site/website/sidebars.json
@@ -9,6 +9,7 @@
       "device",
       "tensor",
       "autograd",
+      "graph",
       "dist-train"
     ],
     "Model Zoo": [


### PR DESCRIPTION
@nudles I have help Rulin to add the sidebar and an empty page for computational graph
@XJDKC So you just need to add you documentation in docs-site/docs/graph.md