### PR TITLE
docs: refresh build guidance and fix typos

### DIFF
--- a/docs-site/docs/autograd.md
+++ b/docs-site/docs/autograd.md
@@ -8,8 +8,8 @@ title: Autograd
 There are two typical ways to implement autograd, via symbolic differentiation
 like [Theano](http://deeplearning.net/software/theano/index.html) or reverse
 differentiation like
-[Pytorch](https://pytorch.org/docs/stable/notes/autograd.html). SINGA follows
-Pytorch way, which records the computation graph and apply the backward
+[PyTorch](https://pytorch.org/docs/stable/notes/autograd.html). SINGA follows
+PyTorch way, which records the computation graph and apply the backward
 propagation automatically after forward propagation. The autograd algorithm is
 explained in details
 [here](https://pytorch.org/docs/stable/notes/autograd.html). We explain the
@@ -58,7 +58,7 @@ There are two member functions for forwarding and backwarding, i.e.,
 `CTensor`), and output `Ctensor`s. To add a specific operation, subclass
 `operation` should implement their own `.forward()` and `.backward()`. The
 `backward()` function is called by the `backward()` function of autograd
-automatically during backward propogation to compute the gradients of inputs
+automatically during backward propagation to compute the gradients of inputs
 (according to the `require_grad` field).
 
 ### Layer
@@ -128,7 +128,7 @@ for i in range(10):
 
 ### Operation + Layer
 
-The following [example](https://github.com/apache/singa/blob/master/examples/autograd/mnist_cnn.py) implemeNts a CNN model using layers provided by the autograd module.
+The following [example](https://github.com/apache/singa/blob/master/examples/autograd/mnist_cnn.py) implements a CNN model using layers provided by the autograd module.
 
 #### Create the layers
 

--- a/docs-site/docs/benchmark-train.md
+++ b/docs-site/docs/benchmark-train.md
@@ -11,7 +11,7 @@ as the application. ResNet-50 has 50 convolution layers for image
 classification. It requires 3.8 GFLOPs to pass a single image (of size 224x224)
 through the network. The input image size is 224x224.
 
-Hardware: we use p2.8xlarge instances from AWS, each of which has 8 Nvidia Tesla
+Hardware: we use p2.8xlarge instances from AWS, each of which has 8 NVIDIA Tesla
 K80 GPUs, 96 GB GPU memory in total, 32 vCPU, 488 GB main memory, 10 Gbps
 network bandwidth.
 

--- a/docs-site/docs/build.md
+++ b/docs-site/docs/build.md
@@ -5,8 +5,9 @@ title: Build SINGA from Source
 
 <!--- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the specific language governing permissions and limitations under the License.  -->
 
-The source files could be downloaded either as a
-[tar.gz file](https://dist.apache.org/repos/dist/dev/singa/), or as a git repo
+The source files can be downloaded either as a
+[tar.gz file](https://dist.apache.org/repos/dist/dev/singa/) or as a Git
+repository:
 
 ```shell
 $ git clone https://github.com/apache/singa.git
@@ -18,8 +19,8 @@ If you want to contribute code to SINGA, refer to
 
 ## Use Conda to build SINGA
 
-Conda-build is a building tool that installs the dependent libraries from
-anaconda cloud and executes the building scripts.
+Conda-build is a build tool that installs the dependent libraries from
+Anaconda Cloud and executes the build scripts.
 
 To install conda-build (after installing conda)
 
@@ -35,21 +36,22 @@ To build the CPU version of SINGA
 conda build tool/conda/singa/
 ```
 
-The above commands have been tested on Ubuntu (14.04, 16.04 and 18.04) and macOS
-10.11. Refer to the [Travis-CI page](https://travis-ci.org/apache/singa) for
-more information.
+SINGA builds are tested via GitHub Actions on Ubuntu 24.04 and macOS 26
+(Arm64). Refer to the
+[GitHub Actions workflows](https://github.com/apache/singa/tree/master/.github/workflows)
+for more information.
 
 ### Build GPU Version
 
-To build the GPU version of SINGA, the building machine must have Nvida GPU, and
-the CUDA driver (>= 384.81), CUDA toolkit (>=9) and cuDNN (>=7) must have be
-installed. The following two Docker images provide the building environment:
+To build the GPU version of SINGA, the build machine must have an NVIDIA GPU,
+and the CUDA driver (>= 384.81), CUDA toolkit (>=9) and cuDNN (>=7) must be
+installed. The following two Docker images provide the build environment:
 
 1. apache/singa:conda-cuda9.0
 2. apache/singa:conda-cuda10.0
 
-Once the building environment is ready, you need to export the CUDA version
-first, and then run conda command to build SINGA
+Once the build environment is ready, you need to export the CUDA version
+first, and then run the conda command to build SINGA
 
 ```shell
 export CUDA=x.y (e.g. 9.0)
@@ -65,8 +67,8 @@ The generated package can be installed directly,
 conda install -c conda-forge --use-local <path to the package file>
 ```
 
-or uploaded to anaconda cloud for others to download and install. You need to
-register an account on anaconda for
+or uploaded to Anaconda Cloud for others to download and install. You need to
+register an account on Anaconda Cloud for
 [uploading the package](https://docs.anaconda.com/anaconda-cloud/user-guide/getting-started/).
 
 ```shell
@@ -76,7 +78,7 @@ anaconda upload -l main <path to the package file>
 ```
 
 After uploading the package to the cloud, you can see it on
-[Anaconda Cloud](https://anaconda.org/) website or via the following command
+the [Anaconda Cloud](https://anaconda.org/) website or via the following command
 
 ```shell
 conda search -c <anaconda username> singa
@@ -114,10 +116,10 @@ installed as the dependent library.
 
 Refer to SINGA
 [Dockerfiles](https://github.com/apache/singa/blob/master/tool/docker/devel/ubuntu/cuda9/Dockerfile#L30)
-for the instructions of installing the dependent libraries on Ubuntu 16.04. You
+for instructions on installing the dependent libraries on Ubuntu 16.04. You
 can also create a Docker container using the [devel images]() and build SINGA
 inside the container. To build SINGA with GPU, DNNL, Python and unit tests, run
-the following instructions
+the following commands
 
 ```shell
 mkdir build    # at the root of singa folder
@@ -129,9 +131,9 @@ pip install .
 ```
 
 The details of the CMake options are explained in the last section of this page.
-The last command install the Python package. You can also run
+The last command installs the Python package. You can also run
 `pip install -e .`, which creates symlinks instead of copying the Python files
-into the site-package folder.
+into the site-packages folder.
 
 If SINGA is compiled with ENABLE_TEST=ON, you can run the unit tests by
 
@@ -139,13 +141,13 @@ If SINGA is compiled with ENABLE_TEST=ON, you can run the unit tests by
 $ ./bin/test_singa
 ```
 
-You can see all the testing cases with testing results. If SINGA passes all
+You can see all the test cases and results. If SINGA passes all
 tests, then you have successfully installed SINGA.
 
-## Use native tools to Build SINGA on Centos7
+## Use native tools to build SINGA on CentOS 7
 
-Building from source will be different for Centos7 as package names
-differ.Follow the instructions given below.
+Building from source will be different for CentOS 7 as package names
+differ. Follow the instructions given below.
 
 ### Installing dependencies
 
@@ -161,7 +163,7 @@ For build-essential
 sudo yum group install "Development Tools"
 ```
 
-For installing swig
+For installing SWIG
 
 ```shell
 sudo yum install pcre-devel
@@ -205,7 +207,7 @@ tests, then you have successfully installed SINGA.
 
 ## Compile SINGA on Windows
 
-Instructions for building on Windows with Python support can be found
+Instructions for building on Windows with Python support can be found on the
 [install-win page](install-win.md).
 
 ## More details about the compilation options
@@ -223,7 +225,7 @@ $ cmake -DUSE_MODULES=ON ..
 $ make
 ```
 
-cmake would download OpenBlas and Protobuf (2.6.1) and compile them together
+CMake would download OpenBLAS and Protobuf (2.6.1) and compile them together
 with SINGA.
 
 You can use `ccmake ..` to configure the compilation options. If some dependent
@@ -254,7 +256,7 @@ better performance.
 
 SINGA has been tested over CUDA 9/10, and cuDNN 7. If cuDNN is installed into
 non-system folder, e.g. /home/bob/local/cudnn/, the following commands should be
-executed for cmake and the runtime to find it
+executed for CMake and the runtime to find it
 
 ```shell
 $ export CMAKE_INCLUDE_PATH=/home/bob/local/cudnn/include:$CMAKE_INCLUDE_PATH
@@ -262,19 +264,19 @@ $ export CMAKE_LIBRARY_PATH=/home/bob/local/cudnn/lib64:$CMAKE_LIBRARY_PATH
 $ export LD_LIBRARY_PATH=/home/bob/local/cudnn/lib64:$LD_LIBRARY_PATH
 ```
 
-The cmake options for CUDA and cuDNN should be switched on
+The CMake options for CUDA and cuDNN should be switched on
 
 ```shell
-# Dependent libs are install already
+# Dependent libraries are already installed
 $ cmake -DUSE_CUDA=ON ..
 $ make
 ```
 
 ### USE_DNNL
 
-User can enable DNNL to enhance the performance of CPU computation.
+Users can enable DNNL to enhance the performance of CPU computation.
 
-Installation guide of DNNL could be found
+The DNNL installation guide can be found
 [here](https://github.com/intel/mkl-dnn#installation).
 
 SINGA has been tested over DNNL v1.1.
@@ -282,7 +284,7 @@ SINGA has been tested over DNNL v1.1.
 To build SINGA with DNNL support:
 
 ```shell
-# Dependent libs are installed already
+# Dependent libraries are already installed
 $ cmake -DUSE_DNNL=ON ..
 $ make
 ```
@@ -302,11 +304,11 @@ $ sudo yum install opencl-headers, viennacl
 Additionally, you will need the OpenCL Installable Client Driver (ICD) for the
 platforms that you want to run OpenCL on.
 
-- For AMD and nVidia GPUs, the driver package should also install the correct
+- For AMD and NVIDIA GPUs, the driver package should also install the correct
   OpenCL ICD.
 - For Intel CPUs and/or GPUs, get the driver from the
   [Intel website.](https://software.intel.com/en-us/articles/opencl-drivers)
-  Note that the drivers provided on that website only supports recent CPUs and
+  Note that the drivers provided on that website only support recent CPUs and
   Iris GPUs.
 - For older Intel CPUs, you can use the `beignet-opencl-icd` package.
 
@@ -334,7 +336,7 @@ $ make
 ### PACKAGE
 
 This setting is used to build the Debian package. Set PACKAGE=ON and build the
-package with make command like this:
+package with the make command like this:
 
 ```shell
 $ cmake -DPACKAGE=ON
@@ -347,21 +349,21 @@ $ make package
 
   A: Please check the detailed error from
   `python -c "from singa import _singa_wrap"`. Sometimes it is caused by the
-  dependent libraries, e.g. there are multiple versions of protobuf, missing of
-  cudnn, numpy version mismatch. Following steps show the solutions for
+  dependent libraries, e.g. multiple versions of protobuf, missing cuDNN
+  libraries, or a NumPy version mismatch. The following steps show solutions for
   different cases
 
-  1. Check the cudnn and cuda. If cudnn is missing or not match with the wheel
-     version, you can download the correct version of cudnn into ~/local/cudnn/
+  1. Check cuDNN and CUDA. If cuDNN is missing or does not match the wheel
+     version, you can download the correct version of cuDNN into ~/local/cudnn/
      and
 
      ```shell
      $ echo "export LD_LIBRARY_PATH=/home/<yourname>/local/cudnn/lib64:$LD_LIBRARY_PATH" >> ~/.bashrc
      ```
 
-  2. If it is the problem related to protobuf. You can install protobuf (3.6.1)
-     from source into a local folder, say ~/local/; Decompress the tar file, and
-     then
+  2. If the problem is related to protobuf, you can install protobuf (3.6.1)
+     from source into a local folder, such as ~/local/. Decompress the tar file,
+     and then
 
      ```shell
      $ ./configure --prefix=/home/<yourname>local
@@ -370,10 +372,10 @@ $ make package
      $ source ~/.bashrc
      ```
 
-  3. If it cannot find other libs including python, then create virtual env
-     using `pip` or `conda`;
+  3. If it cannot find other libraries, including Python, then create a virtual
+     environment using `pip` or `conda`;
 
-  4. If it is not caused by the above reasons, go to the folder of
+  4. If it is not caused by any of the above, go to the folder of
      `_singa_wrap.so`,
 
      ```shell
@@ -382,14 +384,14 @@ $ make package
      >> importlib.import_module('_singa_wrap')
      ```
 
-     Check the error message. For example, if the numpy version mismatches, the
+     Check the error message. For example, if the NumPy version mismatches, the
      error message would be,
 
      ```shell
      RuntimeError: module compiled against API version 0xb but this version of numpy is 0xa
      ```
 
-     Then you need to upgrade the numpy.
+     Then you need to upgrade NumPy.
 
 * Q: Error from running `cmake ..`, which cannot find the dependent libraries.
 
@@ -404,8 +406,8 @@ $ make package
 
 - Q: Error from `make`, e.g. the linking phase
 
-  A: If your libraries are in other folders than system default paths, you need
-  to export the following varaibles
+  A: If your libraries are outside the system default paths, you need
+  to export the following variables
 
   ```shell
   $ export LIBRARY_PATH=<path to your lib file folder>
@@ -421,18 +423,18 @@ $ make package
   $ export CPLUS_INCLUDE_PATH=/opt/OpenBLAS/include:$CPLUS_INCLUDE_PATH
   ```
 
-* Q:While compiling SINGA, I get error `SSE2 instruction set not enabled`
+* Q: While compiling SINGA, I get the error `SSE2 instruction set not enabled`
 
-  A:You can try following command:
+  A: You can try the following command:
 
   ```shell
   $ make CFLAGS='-msse2' CXXFLAGS='-msse2'
   ```
 
-* Q:I get `ImportError: cannot import name enum_type_wrapper` from
+* Q: I get `ImportError: cannot import name enum_type_wrapper` from
   google.protobuf.internal when I try to import .py files.
 
-  A: You need to install the python binding of protobuf, which could be
+  A: You need to install the Python binding of protobuf, which could be
   installed via
 
   ```shell
@@ -463,8 +465,8 @@ $ make package
   $ sudo apt-get install libopenblas-dev
   ```
 
-* Q: When I build protocol buffer, it reports that `GLIBC++_3.4.20` not found in
-  `/usr/lib64/libstdc++.so.6`?
+* Q: When I build Protocol Buffers, it reports that `GLIBC++_3.4.20` is not
+  found in `/usr/lib64/libstdc++.so.6`?
 
   A: This means the linker found libstdc++.so.6 but that library belongs to an
   older version of GCC than was used to compile and link the program. The
@@ -483,9 +485,9 @@ $ make package
 * Q: When I build glog, it reports that "src/logging_unittest.cc:83:20: error:
   ‘gflags’ is not a namespace-name"
 
-  A: It maybe that you have installed gflags with a different namespace such as
-  "google". so glog can't find 'gflags' namespace. Because it is not necessary
-  to have gflags to build glog. So you can change the configure.ac file to
+  A: It may be that you have installed gflags with a different namespace, such
+  as "google", so glog cannot find the `gflags` namespace. Because gflags is not
+  necessary to build glog, you can change the configure.ac file to
   ignore gflags.
 
         1. cd to glog src directory
@@ -494,35 +496,35 @@ $ make package
 
   After this, you can build glog again.
 
-* Q: When using virtual environment, every time I run pip install, it would
-  reinstall numpy. However, the numpy would not be used when I `import numpy`
+* Q: When using a virtual environment, every time I run `pip install`, it
+  reinstalls NumPy. However, NumPy is not used when I run `import numpy`.
 
-  A: It could be caused by the `PYTHONPATH` which should be set to empty when
-  you are using virtual environment to avoid the conflicts with the path of the
+  A: It could be caused by the `PYTHONPATH`, which should be set to empty when
+  you are using a virtual environment to avoid conflicts with the path of the
   virtual environment.
 
-* Q: When compiling PySINGA from source, there is a compilation error due to the
-  missing of <numpy/objectarray.h>
+* Q: When compiling PySINGA from source, there is a compilation error because
+  <numpy/objectarray.h> is missing
 
-  A: Please install numpy and export the path of numpy header files as
+  A: Please install NumPy and export the path of its header files as
 
         $ export CPLUS_INCLUDE_PATH=`python -c "import numpy; print numpy.get_include()"`:$CPLUS_INCLUDE_PATH
 
 * Q: When I run SINGA in Mac OS X, I got the error "Fatal Python error:
   PyThreadState_Get: no current thread Abort trap: 6"
 
-  A: This error happens typically when you have multiple version of Python on
+  A: This error happens typically when you have multiple versions of Python on
   your system and you installed SINGA via pip (this problem is resolved for
-  installation via conda), e.g, the one comes with the OS and the one installed
-  by Homebrew. The Python linked by PySINGA must be the same as the Python
-  interpreter. You can check your interpreter by `which python` and check the
-  Python linked by PySINGA via `otool -L <path to _singa_wrap.so>`. To fix this
+  installation via conda), e.g., the version that comes with the OS and the one
+  installed by Homebrew. The Python linked by PySINGA must be the same as the
+  Python interpreter. You can check your interpreter by `which python` and check the Python
+  linked by PySINGA via `otool -L <path to _singa_wrap.so>`. To fix this
   error, compile SINGA with the correct version of Python. In particular, if you
   build PySINGA from source, you need to specify the paths when invoking
   [cmake](http://stackoverflow.com/questions/15291500/i-have-2-versions-of-python-installed-but-cmake-is-using-older-version-how-do)
 
         $ cmake -DPYTHON_LIBRARY=`python-config --prefix`/lib/libpython2.7.dylib -DPYTHON_INCLUDE_DIR=`python-config --prefix`/include/python2.7/ ..
 
-  If installed PySINGA from binary packages, e.g. debian or wheel, then you need
-  to change the python interpreter, e.g., reset the \$PATH to put the correct
+  If you installed PySINGA from binary packages, e.g. Debian packages or wheels,
+  then you need to change the Python interpreter, e.g., reset the \$PATH to put the correct
   path of Python at the front position.

--- a/docs-site/docs/contribute-code.md
+++ b/docs-site/docs/contribute-code.md
@@ -12,7 +12,7 @@ The SINGA codebase follows the Google Style for both
 [Python](http://google.github.io/styleguide/pyguide.html) code.
 
 A simple way to enforce the Google coding styles is to use the linting and
-formating tools in the Visual Studio Code editor:
+formatting tools in the Visual Studio Code editor:
 
 - [C/C++ extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools)
 - [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
@@ -113,7 +113,7 @@ If you update the CPP code, you need to recompile SINGA
 [from source](./build.md). It is recommended to use the native building tools in
 the `*-devel` Docker images or `conda build`.
 
-If you only update the Python code, you can install SINGAS once, and then copy
+If you only update the Python code, you can install SINGA once, and then copy
 the updated Python files to replace those in the Python installation folder,
 
 ```shell

--- a/docs-site/docs/contribute-docs.md
+++ b/docs-site/docs/contribute-docs.md
@@ -21,7 +21,7 @@ Try to follow the
 
 1. Remove 'please' from an instruction. 'Please click...' VS 'Click ...'.
 2. Follow the
-   [standard captitalization rules](https://owl.purdue.edu/owl/general_writing/mechanics/help_with_capitals.html).
+   [standard capitalization rules](https://owl.purdue.edu/owl/general_writing/mechanics/help_with_capitals.html).
 3. Use 'you' instead of 'we' in the instructions.
 4. Use present tense and avoid 'will'
 5. Prefer active voice than passive voice.
@@ -31,9 +31,9 @@ In addition, to make the documentation consistent,
 1. Keep the line short, e.g., length<=80
 2. Use the relative path assuming that we are in the root folder of the repo,
    e.g., `doc-site/docs` refers to `singa-doc/docs-site/docs`
-3. Higlight the command, path, class function and variable using backticks,
+3. Highlight the command, path, class function and variable using backticks,
    e.g., `Tensor`, `singa-doc/docs-site/docs`.
-4. To hightlight other terms/concepts, use _graph_ or **graph**
+4. To highlight other terms/concepts, use _graph_ or **graph**
 
 The [prettier tool](https://prettier.io/) used by this project will auto-format
 the code according to the

--- a/docs-site/docs/device.md
+++ b/docs-site/docs/device.md
@@ -13,9 +13,9 @@ class.
 
 ## Specific devices
 
-Currently, SINGA has three Device implmentations,
+Currently, SINGA has three Device implementations,
 
-1.  CudaGPU for an Nvidia GPU card which runs Cuda code
+1.  CudaGPU for an NVIDIA GPU card which runs Cuda code
 2.  CppCPU for a CPU which runs Cpp code
 3.  OpenclGPU for a GPU card which runs OpenCL code
 

--- a/docs-site/docs/dist-train.md
+++ b/docs-site/docs/dist-train.md
@@ -216,7 +216,7 @@ Note that we need to generate a NCCL ID here to be used for collective
 communication, and then pass it to all the processes. The NCCL ID is like a
 ticket, where only the processes with this ID can join the all-reduce operation.
 (Later if we use MPI, the passing of NCCL ID is not necessary, because the ID is
-broadcased by MPI in our code automatically)
+broadcast by MPI in our code automatically)
 
 (ii) `world_size`
 

--- a/docs-site/docs/download.md
+++ b/docs-site/docs/download.md
@@ -69,7 +69,7 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
     - Add the news for the SIGMOD Systems Award.
 
   * Fix bugs
-    - Fix the Github Actions for online code testing.
+    - Fix the GitHub Actions for online code testing.
 
 
 ## V4.2.0 (15 March 2024):
@@ -167,13 +167,13 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
     - Add sparsification implementation for mnist in the large dataset cnn
       example.
     - Update the cifar datasets downloading to local directories.
-    - Extend the cifar datasets load function for customized directorires.
+    - Extend the cifar datasets load function for customized directories.
 
   * Enhance the webpage
     - Update online documentation for distributed training.
 
   * Promote code quality
-    - Update inline comments for prepreocessing and data loading
+    - Update inline comments for preprocessing and data loading
 
   * Update the PIL image module
 
@@ -224,7 +224,7 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
   * New examples
     - Add one cifar-10 distributed CNN example for benchmarking the performance
       of the distributed training.
-    - Add one large CNN example for training with a dataset from the filesysetm.
+    - Add one large CNN example for training with a dataset from the filesystem.
   * Enhance distributed training
     - Improve the data augmentation module for faster distributed training.
     - Add device synchronization for more accurate time measurements during the
@@ -266,7 +266,7 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
       of SINGA.
     - Add a SONNXModel which implements from Model to provide uniform API and
       features.
-  * Replace the Travis CI with Github workflow. Add quality and coverage
+  * Replace the Travis CI with GitHub workflow. Add quality and coverage
     management.
   * Add compiling and packaging scripts to create wheel packages for
     distribution.
@@ -318,7 +318,7 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
 - [Release Notes 1.2.0 (incubating)](http://singa.apache.org/docs/releases/RELEASE_NOTES_1.2.0.html)
 - New features and major updates,
   - Implement autograd (currently support MLP model)
-  - Upgrade PySinga to support Python 3
+  - Upgrade PySINGA to support Python 3
   - Improve the Tensor class with the stride field
   - Upgrade cuDNN from V5 to V7
   - Add VGG, Inception V4, ResNet, and DenseNet for ImageNet classification
@@ -339,7 +339,7 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
   - Create Amazon AMI for SINGA (CPU version)
   - Integrate with Jenkins for automatically generating Wheel and Debian
     packages (for installation), and updating the website.
-  - Enhance the FeedFowardNet, e.g., multiple inputs and verbose mode for
+  - Enhance the FeedForwardNet, e.g., multiple inputs and verbose mode for
     debugging
   - Add Concat and Slice layers
   - Extend CrossEntropyLoss to accept instance with multiple labels
@@ -349,7 +349,7 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
   - Compile mandatory dependent libraries together with SINGA code
   - Enable Java binding (basic) for SINGA
   - Add version ID in checkpointing files
-  - Add Rafiki toolkit for providing RESTFul APIs
+  - Add Rafiki toolkit for providing RESTful APIs
   - Add examples pretrained from Caffe, including GoogleNet
 
 ## Incubating v1.0.0 (8 September 2016):
@@ -361,7 +361,7 @@ You can also check the SHA512 or MD5 values to see if the download is completed.
 - New features and major updates,
   - Tensor abstraction for supporting more machine learning models.
   - Device abstraction for running on different hardware devices, including CPU,
-    (Nvidia/AMD) GPU and FPGA (to be tested in later versions).
+    (NVIDIA/AMD) GPU and FPGA (to be tested in later versions).
   - Replace GNU autotool with cmake for compilation.
   - Support Mac OS
   - Improve Python binding, including installation and programming

--- a/docs-site/docs/examples.md
+++ b/docs-site/docs/examples.md
@@ -7,7 +7,7 @@ title: Examples
 
 This page lists some example deep learning tasks using SINGA. The source code is
 maintained inside SINGA repo on
-[Github](https://github.com/apache/singa/tree/master/examples). For examples
+[GitHub](https://github.com/apache/singa/tree/master/examples). For examples
 running on CPU or single GPU using SINGA Python APIs, they are also available on
 [Google Colab](https://colab.research.google.com/). You can run them directly on
 Google Cloud without setting up the environment locally. The link to each

--- a/docs-site/docs/git-workflow.md
+++ b/docs-site/docs/git-workflow.md
@@ -7,13 +7,13 @@ title: Git Workflow
 
 ## For Developers
 
-1. Fork the [SINGA Github repository](https://github.com/apache/singa) to your
-   own Github account.
+1. Fork the [SINGA GitHub repository](https://github.com/apache/singa) to your
+   own GitHub account.
 
-2. Clone the **repo** (short for repository) from your Github
+2. Clone the **repo** (short for repository) from your GitHub
 
    ```shell
-   git clone https://github.com/<Github account>/singa.git
+   git clone https://github.com/<GitHub account>/singa.git
    git remote add upstream https://github.com/apache/singa.git
    ```
 
@@ -54,9 +54,9 @@ title: Git Workflow
    ```
 
 5. [Rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) `feature-foo`
-   onto the `dev` branch and push commits to your own Github account (the new
+   onto the `dev` branch and push commits to your own GitHub account (the new
    branch). The rebase operation is to make the commit history clean. The
-   following git instructors should be executed after committing the current
+   following Git instructions should be executed after committing the current
    work:
 
    ```shell
@@ -77,15 +77,15 @@ title: Git Workflow
    rebase; and your branch now has the latest code from the dev branch and your
    own branch.
 
-6. Open a pull request (PR) against the dev branch of apache/singa on Github
+6. Open a pull request (PR) against the dev branch of apache/singa on GitHub
    website. If you want to inform other contributors who worked on the same
-   files, you can find the file(s) on Github and click "Blame" to see a
+   files, you can find the file(s) on GitHub and click "Blame" to see a
    line-by-line annotation of who changed the code last. Then, you can add
    @username in the PR description to ping them immediately. Please state that
    the contribution is your original work and that you license the work to the
    project under the project's open source license. Further commits (e.g., bug
    fix) to your new branch will be added to this pull request automatically by
-   Github.
+   GitHub.
 
 7. Wait for committers to review the PR. During this time, the dev of SINGA may
    have been updated by others, and then you need to
@@ -98,7 +98,7 @@ title: Git Workflow
    [The Golden Rule of Rebasing](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)
    for the details of when to avoid using rebase. Another simple solution to
    update the PR (to fix conflicts or commit errors) is to checkout a new branch
-   from the latest dev branch of Apache SINGAS repo; copy and paste the
+   from the latest dev branch of Apache SINGA repo; copy and paste the
    updated/added code; commit and send a new PR.
 
 ## For Committers
@@ -112,8 +112,8 @@ repo. Before merging each PR, the committer should
 
 There are two approaches to merge a pull request:
 
-- On Github. Follow the [instructions](https://gitbox.apache.org/setup/) to
-  connect your Apache account with your Github account. After that you can
+- On GitHub. Follow the [instructions](https://gitbox.apache.org/setup/) to
+  connect your Apache account with your GitHub account. After that you can
   directly merge PRs on GitHub.
 - To merge pull request https://github.com/apache/singa/pull/xxx via command
   line, the following instructions should be executed,

--- a/docs-site/docs/graph.md
+++ b/docs-site/docs/graph.md
@@ -136,7 +136,7 @@ class MLP(model.Model):
         ...
 ```
 
-The `Linear` layer is composed of the `mutmul` operator. `autograd` implements
+The `Linear` layer is composed of the `matmul` operator. `autograd` implements
 the `matmul` operator by calling the function `Mult` exposed from CPP via SWIG.
 
 ```python
@@ -203,7 +203,7 @@ four operations to the CUDA stream: addition, free `a`, malloc `b`, and
 multiplication. The memory pool is then able to share the memory released by `a`
 with `b` instead of ask the GPU to do real malloc for `b`.
 
-Other optimization techniques e.g., from compliers, such as common
+Other optimization techniques e.g., from compilers, such as common
 sub-expression elimination and parallelizing operations on different CUDA
 streams can also be applied.
 
@@ -339,7 +339,7 @@ Tensor GpuConvBackwardx(const Tensor &dy, const Tensor &W, const Tensor &x,
 - Result
   <table style="text-align: center">
       <tr>
-          <th style="text-align: center">Batchsize</th>
+          <th style="text-align: center">Batch size</th>
           <th style="text-align: center">Cases</th>
           <th style="text-align: center">Mem(MB)</th>
           <th style="text-align: center">Time(s)</th>
@@ -438,7 +438,7 @@ Tensor GpuConvBackwardx(const Tensor &dy, const Tensor &W, const Tensor &x,
 - Result
   <table style="text-align: center">
       <tr>
-          <th style="text-align: center">Batchsize</th>
+          <th style="text-align: center">Batch size</th>
           <th style="text-align: center">Cases</th>
           <th style="text-align: center">Mem(MB)</th>
           <th style="text-align: center">Time(s)</th>

--- a/docs-site/docs/half-precision.md
+++ b/docs-site/docs/half-precision.md
@@ -85,12 +85,12 @@ This half implementation is integrated in C++ backend as general half type
 support.
 
 To run on GPU, `__half` is available in Cuda math API. To support `__half` math
-operation, it is required to compile against Nvidia compute arch > 6.0 (Pascal).
+operation, it is required to compile against NVIDIA compute arch > 6.0 (Pascal).
 
-### Nvidia Hardware Acceleration: Tensor Core
+### NVIDIA Hardware Acceleration: Tensor Core
 
-Tensor Core released by Nvidia further accelerates half precision and multiples
-throughput for operations like GEMM(CuBlas) and convolution(CuDNN). To enable
+Tensor Core released by NVIDIA further accelerates half precision and multiples
+throughput for operations like GEMM(cuBLAS) and convolution(cuDNN). To enable
 Tensor core operation, there are a few restriction on GEMM dimensions,
 convolution channel size, Cuda version, and GPU version(Turing or later) and
 etc.

--- a/docs-site/docs/history-singa.md
+++ b/docs-site/docs/history-singa.md
@@ -27,7 +27,7 @@ Rafiki in your research:
   Chin Ooi, Jie Shao, Moaz Reyad.
   [Rafiki: Machine Learning as an Analytics Service System](http://www.vldb.org/pvldb/vol12/p128-wang.pdf).
   [VLDB 2019](http://vldb.org/2019/)
-  ([BibTex](https://dblp.org/rec/bib2/journals/pvldb/WangWGZCNOS18.bib)).
+  ([BibTeX](https://dblp.org/rec/bib2/journals/pvldb/WangWGZCNOS18.bib)).
 
 Companies like [NetEase](http://tech.163.com/17/0602/17/CLUL016I00098GJ5.html),
 [yzBigData](http://www.yzbigdata.com/en/index.html),

--- a/docs-site/docs/how-to-release.md
+++ b/docs-site/docs/how-to-release.md
@@ -38,7 +38,7 @@ in SINGA.
    - The online documentation on the Apache website is up to date.
 
 4. Prepare the RELEASE_NOTES file. Include the following items, Introduction,
-   Features, Bugs (link to JIRA or Github PR), Changes, Dependency list,
+   Features, Bugs (link to JIRA or GitHub PR), Changes, Dependency list,
    Incompatibility issues. Follow this
    [example](http://commons.apache.org/proper/commons-digester/commons-digester-3.0/RELEASE-NOTES.txt).
 
@@ -128,7 +128,7 @@ in SINGA.
    The signature file is:
    https://dist.apache.org/repos/dist/dev/singa/3.1.0.rc2/apache-singa-3.1.0.rc2.tar.gz.asc
 
-   The Github tag is at:
+   The GitHub tag is at:
    https://github.com/apache/singa/releases/tag/3.1.0.rc2
 
    The documentation website is at

--- a/docs-site/docs/install-win.md
+++ b/docs-site/docs/install-win.md
@@ -198,7 +198,7 @@ A video tutorial for the build process can be found here:
   ```
 
   - From Visual Studio:
-    - right click on the test_singa project and choose 'Set as StartUp Project'.
+    - right click on the test_singa project and choose 'Set as Startup Project'.
     - from the Debug menu, choose 'Start Without Debugging'
 
 A video tutorial for running the unit tests can be found here:
@@ -391,7 +391,7 @@ A video tutorial for this part can be found here:
     ```
 
   - From Visual Studio:
-    - right click on the test_singa project and choose 'Set as StartUp Project'.
+    - right click on the test_singa project and choose 'Set as Startup Project'.
     - from the Debug menu, choose 'Start Without Debugging'
 
 A video tutorial for running the unit tests can be found here:

--- a/docs-site/docs/installation.md
+++ b/docs-site/docs/installation.md
@@ -62,7 +62,7 @@ $ docker run -it apache/singa:X.Y.Z-cpu-ubuntu16.04 /bin/bash
 ```
 
 2. With GPU enabled. Install
-   [Nvidia-Docker](https://github.com/NVIDIA/nvidia-docker) after install
+   [NVIDIA-Docker](https://github.com/NVIDIA/nvidia-docker) after install
    Docker.
 
 ```shell
@@ -81,7 +81,7 @@ version-(cpu|gpu)[-devel]
 | --------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `version` | SINGA version                    | '2.0.0-rc0', '2.0.0', '1.2.0'                                                                                                                                             |
 | `cpu`     | the image cannot run on GPUs     | 'cpu'                                                                                                                                                                     |
-| `gpu`     | the image can run on Nvidia GPUs | 'gpu', or 'cudax.x-cudnnx.x' e.g., 'cuda10.0-cudnn7.3'                                                                                                                    |
+| `gpu`     | the image can run on NVIDIA GPUs | 'gpu', or 'cudax.x-cudnnx.x' e.g., 'cuda10.0-cudnn7.3'                                                                                                                    |
 | `devel`   | indicator for development        | if absent, SINGA Python package is installed for runtime only; if present, the building environment is also created, you can recompile SINGA from source at '/root/singa' |
 | `OS`      | indicate OS version number       | 'ubuntu16.04', 'ubuntu18.04'                                                                                                                                              |
 

--- a/docs-site/docs/issue-tracking.md
+++ b/docs-site/docs/issue-tracking.md
@@ -8,4 +8,4 @@ title: Issue Tracking
 SINGA used [JIRA](https://issues.apache.org/jira/browse/singa) to manage issues
 including bugs, new features and discussions.
 
-We are now moving to [Github Issues](https://github.com/apache/singa/issues).
+We are now moving to [GitHub Issues](https://github.com/apache/singa/issues).

--- a/docs-site/docs/onnx.md
+++ b/docs-site/docs/onnx.md
@@ -339,7 +339,7 @@ The following operators are supported:
 
 ## Implementation
 
-The code of SINGA ONNX locates at `python/singa/soonx.py`. There are four main
+The code of SINGA ONNX locates at `python/singa/sonnx.py`. There are four main
 class, `SingaFrontend`, `SingaBackend`, `SingaRep` and `SONNXModel`.
 `SingaFrontend` translates a SINGA model to an ONNX model; `SingaBackend`
 translates an ONNX model to `SingaRep` object which stores all SINGA operators
@@ -388,7 +388,7 @@ The first step of `_onnx_model_to_singa_ops` has four steps, the first one is to
 call `_parse_graph_params` to get all tensors stored as `params`. Then call
 `_parse_graph_inputs_outputs` to get all input and output information stores as
 `inputs` and `outputs`. Finally, it iterators all nodes within the ONNX graph
-and parses it by `_onnx_node_to_singa_op` as SIGNA operators or layers and store
+and parses it by `_onnx_node_to_singa_op` as SINGA operators or layers and store
 them as `outputs`. Some weights are stored within an ONNX node called
 `Constant`, SONNX can handle them by `_onnx_constant_to_np` to store it into
 `params`.

--- a/docs-site/docs/optimizer.md
+++ b/docs-site/docs/optimizer.md
@@ -7,7 +7,7 @@ title: Optimizer
 
 SINGA supports various popular optimizers including stochastic gradient descent
 with momentum, Adam, RMSProp, and AdaGrad, etc. For each of the optimizer, it
-supports to use a decay schedular to schedule the learning rate to be applied in
+supports to use a decay scheduler to schedule the learning rate to be applied in
 different epochs. The optimizers and the decay schedulers are included in
 `singa/opt.py`.
 

--- a/docs-site/docs/software-stack.md
+++ b/docs-site/docs/software-stack.md
@@ -29,10 +29,10 @@ schedules the operations for executing, e.g., on CUDA streams or CPU threads.
 Depending on the hardware and its programming language, SINGA have implemented
 the following specific device classes:
 
-- **CudaGPU** represents an Nvidia GPU card. The execution units are the CUDA
+- **CudaGPU** represents an NVIDIA GPU card. The execution units are the CUDA
   streams.
 - **CppCPU** represents a normal CPU. The execution units are the CPU threads.
-- **OpenclGPU** represents normal GPU card from both Nvidia and AMD. The
+- **OpenclGPU** represents normal GPU card from both NVIDIA and AMD. The
   execution units are the CommandQueues. Given that OpenCL is compatible with
   many hardware devices, e.g. FPGA and ARM, the OpenclGPU has the potential to
   be extended for other devices.
@@ -64,8 +64,8 @@ are implemented separately for different hardware devices
 
 The neural network specific operators are also implemented separately, e.g.,
 
-- GpuConvFoward (convolution.h) implements the forward function of convolution
-  via CuDNN on Nvidia GPU.
+- GpuConvForward (convolution.h) implements the forward function of convolution
+  via cuDNN on NVIDIA GPU.
 - CpuConvForward (convolution.h) implements the forward function of convolution
   using CPP on CPU.
 

--- a/docs-site/docs/source-repository.md
+++ b/docs-site/docs/source-repository.md
@@ -14,7 +14,7 @@ The following is a link to the online source repository.
 
 - https://gitbox.apache.org/repos/asf?p=singa.git
 
-There is a Github mirror at
+There is a GitHub mirror at
 
 - https://github.com/apache/singa
 

--- a/docs-site/docs/tensor.md
+++ b/docs-site/docs/tensor.md
@@ -134,7 +134,7 @@ between `device`s via `to_device()` function.
 ```python
 
 """
-  code snipet from examples/mlp/module.py
+  code snippet from examples/mlp/module.py
 """
 
 label = get_label()

--- a/docs-site/docs/time-profiling.md
+++ b/docs-site/docs/time-profiling.md
@@ -7,7 +7,7 @@ title: Time Profiling
 
 SINGA supports the time profiling of each of the operators buffered in the
 graph. To utilize the time profiling function, we first call the
-`device.SetVerbosity` method to set the verbosity of the time profilier, and
+`device.SetVerbosity` method to set the verbosity of the time profiler, and
 then call the `device.PrintTimeProfiling` to print out the results of time
 profiling.
 


### PR DESCRIPTION
## Summary

- update the build guide with the current GitHub Actions workflows and tested Ubuntu 24.04 and macOS 26 Arm64 environments
- correct spelling, capitalization, and product-name inconsistencies across the current documentation
- preserve historical release notes unchanged

## Validation

- `git diff --check`
- documentation-only changes; site build not run because local Node dependencies are not installed